### PR TITLE
Nifi 11259 Run Kafak IT tests only during integration-tests workflow (not ci-worlflpow) because ci-workflow does not have docker for all OSes

### DIFF
--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-3-integration/src/test/java/org/apache/nifi/kafka/processors/AbstractPublishKafkaIT.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-3-integration/src/test/java/org/apache/nifi/kafka/processors/AbstractPublishKafkaIT.java
@@ -16,10 +16,5 @@
  */
 package org.apache.nifi.kafka.processors;
 
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.common.serialization.StringDeserializer;
-
-import java.util.Properties;
-
 public abstract class AbstractPublishKafkaIT extends AbstractKafkaBaseIT {
 }

--- a/nifi-nar-bundles/nifi-kafka-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-kafka-bundle/pom.xml
@@ -61,27 +61,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.2.3</version>
-                <executions>
-                    <execution>
-                        <id>integration-tests</id>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                        <configuration>
-                            <includes>
-                                <include>**/*IT.java</include>
-                            </includes>
-                            <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
-                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Run Kafak IT tests only during integration-tests workflow (not ci-worlflpow) because ci-workflow does not have docker for all OSes